### PR TITLE
DM-2948: Remove datarel dependency

### DIFF
--- a/ups/lsst_distrib.table
+++ b/ups/lsst_distrib.table
@@ -1,7 +1,6 @@
 setupRequired(lsst_apps)
 setupRequired(ctrl_execute)
 setupRequired(ctrl_platform_lsstvc)
-setupRequired(datarel)
 setupOptional(meas_extensions_convolved)
 setupOptional(meas_extensions_shapeHSM)
 setupOptional(meas_extensions_photometryKron)


### PR DESCRIPTION
This has the side effect of removing `cat` and `db` from `lsst_distrib` builds. This is important for RFC-449 from @fritzm. @jhoblitt / @jonathansick  it assumes that the doxygen build is no longer relying on `datarel` (in my tests `lsst_distrib` works fine as an anchor).