### PR TITLE
DM-37132: Add ctrl_platform_s3df to lsst_distrib.

### DIFF
--- a/ups/lsst_distrib.table
+++ b/ups/lsst_distrib.table
@@ -1,5 +1,6 @@
 setupRequired(lsst_apps)
 setupRequired(ctrl_execute)
+setupOptional(ctrl_platform_s3df)
 setupRequired(ctrl_mpexec)
 setupRequired(ctrl_bps)
 setupRequired(lsst_bps_plugins)


### PR DESCRIPTION
While technically this doesn't need to be distributed outside the USDF (S3DF), it's expedient to have it be built by the normal release machinery.